### PR TITLE
Enhanced synchronization among threads to avoid unnecessary spin lock

### DIFF
--- a/bladegps.h
+++ b/bladegps.h
@@ -5,6 +5,10 @@
 #include <stdio.h>
 #include <libbladeRF.h>
 #include <string.h>
+#ifdef _WIN32
+// To avoid conflict between time.h and pthread.h on Windows
+#define HAVE_STRUCT_TIMESPEC
+#endif
 #include <pthread.h>
 #include "gpssim.h"
 
@@ -58,10 +62,12 @@ typedef struct {
 	gps_t gps;
 
 	int status;
+	bool finished;
 	int16_t *fifo;
 	long head, tail;
 	size_t sample_length;
 
+	pthread_cond_t fifo_read_ready;
 	pthread_cond_t fifo_write_ready;
 
 	double time;

--- a/gpssim.c
+++ b/gpssim.c
@@ -2035,10 +2035,11 @@ void *gps_task(void *arg)
 
 		// Write into FIFO
 		memcpy(&(s->fifo[s->head * 2]), iq_buff, NUM_IQ_SAMPLES * 2 * sizeof(short));
-		
+
 		s->head += (long)NUM_IQ_SAMPLES;
 		if (s->head >= FIFO_LENGTH)
 			s->head -= FIFO_LENGTH;
+		pthread_cond_signal(&(s->fifo_read_ready));
 #endif
 		//
 		// Update navigation message and channel allocation every 30 seconds
@@ -2079,6 +2080,7 @@ void *gps_task(void *arg)
 		printf("\rTime into run = %4.1f", grx.sec-g0.sec);
 		fflush(stdout);
 	}
+	s->finished = true;
 
 	// Free I/Q buffer
 	free(iq_buff);


### PR DESCRIPTION
Originally, synchronization was one direction from tx_task to GPS_task. I added pthread's conditional wait&signal synchronization to the other direction, too. It may eliminate unnecessary spin lock loop at tx_task. 
I also added synchronization between main task and tx_thread using pthread_join().
One more minor change is, inserted a macro definition HAVE_STRUCT_TIMESPEC to eliminate compilation error with VisualStudio. 
