### PR TITLE
Mac OSX Compatibility and Updates to ephemeris file fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ bladegps
 
 # Password File for Wget
 .wgetrc
+
+#FPGA images
+external/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Temporary Items
 *.o
 *.swp
 bladegps
+
+# Password File for Wget
+.wgetrc

--- a/.wgetrc
+++ b/.wgetrc
@@ -1,0 +1,2 @@
+http_user=<INSERT_USERNAME>
+http_password=<INSERT_PASSWORD>

--- a/.wgetrc
+++ b/.wgetrc
@@ -1,2 +1,0 @@
-http_user=<INSERT_USERNAME>
-http_password=<INSERT_PASSWORD>

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: bladegps
 
 SHELL=/bin/bash
 CC=gcc
-CFLAGS=-O3 -Wall -I../bladeRF/host/libraries/libbladeRF/include
+CFLAGS+=-O3 -Wall -I../bladeRF/host/libraries/libbladeRF/include
 LDFLAGS=-lm -lpthread -L../bladeRF/host/build/output -lbladeRF
 
 bladegps: bladegps.o gpssim.o

--- a/Readme.md
+++ b/Readme.md
@@ -74,6 +74,66 @@ $ cd ../../../bladeGPS
 $ make
 ```
 
+### Build on Mac OS X (Catalina)
+
+1. Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12)
+
+2. Install Xcode Command Line Tools
+
+ ```
+$ xcode-select --install
+```
+3. Install [MacPorts](https://www.macports.org/install.php)
+
+4. Create a symlink to port
+
+ ```
+$ sudo ln -s /opt/local/bin/port /usr/local/bin/port
+```
+
+5. Install bladeRF
+
+ ```
+$ sudo port install bladeRF +tecla
+```
+
+6. Install cmake
+
+ ```
+$ sudo port install cmake
+```
+
+7. Retrive the bladeRF source in a directory next to the current directory.
+
+ ```
+$ cd ..
+$ git clone git@github.com:Nuand/bladeRF.git
+```
+
+8. Build the bladeRF host library.
+
+ ```
+$ cd bladeRF/host
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make && sudo make install
+```
+
+9. Install libomp and wget.
+
+ ```
+$ sudo port install libomp
+$ sudo port install wget
+```
+
+10. Compile for \_MACOSX with OpenMP path and build bladeGPS.
+
+ ```
+$ cd ../../../bladeGPS
+$ make CFLAGS=”-I/opt/local/include/libomp _MACOSX”
+```
+
 ### License
 
 Copyright &copy; 2015 Takuji Ebinuma  

--- a/gpssim.c
+++ b/gpssim.c
@@ -14,7 +14,11 @@
 #include <unistd.h>
 // For _kbhit() and _getch() on Linux
 #include <termios.h>
+#ifdef _MACOSX
+#include <stdio.h>
+#else
 #include <stdio_ext.h> // for __fpurge()
+#endif
 #endif
 
 #include "gpssim.h"
@@ -1946,8 +1950,11 @@ int _getch()
 	int ch;
 	
 	ch = getchar();
+#ifdef _MACOSX
+	fpurge(stdin); // Clear STDIN buffer
+#else
 	__fpurge(stdin); // Clear STDIN buffer
-	
+#endif
 	return ch;
 }
 #endif

--- a/run_bladerfGPS.sh
+++ b/run_bladerfGPS.sh
@@ -25,18 +25,22 @@ if [ ! -e "$brdc_file_year" ]; then
 fi
 
 if [ ! -e "external/prebuilt/fpga_images/hostedx115.rbf" ]; then
+  echo "downloading hostedx115.rbf to external/prebuilt/fpga_images"
   wget "https://www.nuand.com/fpga/v0.11.0/hostedx115.rbf" -P external/prebuilt/fpga_images
 fi
 
 if [ ! -e "external/prebuilt/fpga_images/hostedx40.rbf" ]; then
+  echo "downloading hostedx40.rbf to external/prebuilt/fpga_images"
   wget "https://www.nuand.com/fpga/v0.11.0/hostedx40.rbf" -P external/prebuilt/fpga_images
 fi
 
 if [ ! -e "external/prebuilt/fpga_images/hostedxA4.rbf" ]; then
+  echo "downloading hostedxA4.rbf to external/prebuilt/fpga_images"
   wget "https://www.nuand.com/fpga/v0.11.0/hostedxA4.rbf" -P external/prebuilt/fpga_images
 fi
 
 if [ ! -e "external/prebuilt/fpga_images/hostedxA9.rbf" ]; then
+  echo "downloading hostedxA9.rbf to external/prebuilt/fpga_images"
   wget "https://www.nuand.com/fpga/v0.11.0/hostedxA9.rbf" -P external/prebuilt/fpga_images
 fi
 

--- a/run_bladerfGPS.sh
+++ b/run_bladerfGPS.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 
-export WGETRC=./.wgetrc
+pwd
+export BLADERF_SEARCH_DIR="./external/prebuilt/fpga_images" 
 year=`date -u +%Y`
 day=`date -u +%j`
 
 brdc_file="brdc${day}0.${year: -2}n"
 brdc_file_year="brdc${year}_${day}0.${year: -2}n"
+
+if [ ! -e ".wgetrc" ]; then
+  echo -e "http_user=<INSERT_USERNAME>\nhttp_password=<INSERT_PASSWORD>" > .wgetrc
+  echo "Enter your CDDIS portal credentials into .wgetrc and then re-run"
+  exit
+fi
+
+export WGETRC=./.wgetrc
 
 if [ ! -e "$brdc_file_year" ]; then
 	wget --auth-no-challenge "https://cddis.nasa.gov/archive/gnss/data/daily/${year}/brdc/${brdc_file}.Z" -O ${brdc_file_year}.Z
@@ -14,6 +23,22 @@ if [ ! -e "$brdc_file_year" ]; then
 		exit
 	fi
 	uncompress ${brdc_file_year}.Z
+fi
+
+if [ ! -e "external/prebuilt/fpga_images/hostedx115.rbf" ]; then
+  wget "https://www.nuand.com/fpga/v0.11.0/hostedx115.rbf" -P external/prebuilt/fpga_images
+fi
+
+if [ ! -e "external/prebuilt/fpga_images/hostedx40.rbf" ]; then
+  wget "https://www.nuand.com/fpga/v0.11.0/hostedx40.rbf" -P external/prebuilt/fpga_images
+fi
+
+if [ ! -e "external/prebuilt/fpga_images/hostedxA4.rbf" ]; then
+  wget "https://www.nuand.com/fpga/v0.11.0/hostedxA4.rbf" -P external/prebuilt/fpga_images
+fi
+
+if [ ! -e "external/prebuilt/fpga_images/hostedxA9.rbf" ]; then
+  wget "https://www.nuand.com/fpga/v0.11.0/hostedxA9.rbf" -P external/prebuilt/fpga_images
 fi
 
 ./bladegps -e $brdc_file_year -t `date -u +'%Y/%m/%d,%H:%M:%S'` $*

--- a/run_bladerfGPS.sh
+++ b/run_bladerfGPS.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-pwd
 export BLADERF_SEARCH_DIR="./external/prebuilt/fpga_images" 
 year=`date -u +%Y`
 day=`date -u +%j`

--- a/run_bladerfGPS.sh
+++ b/run_bladerfGPS.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export WGETRC=./.wgetrc
 year=`date -u +%Y`
 day=`date -u +%j`
 
@@ -7,8 +8,7 @@ brdc_file="brdc${day}0.${year: -2}n"
 brdc_file_year="brdc${year}_${day}0.${year: -2}n"
 
 if [ ! -e "$brdc_file_year" ]; then
-	wget ftp://cddis.gsfc.nasa.gov/gnss/data/daily/${year}/brdc/${brdc_file}.Z -O ${brdc_file_year}.Z
-	
+	wget --auth-no-challenge "https://cddis.nasa.gov/archive/gnss/data/daily/${year}/brdc/${brdc_file}.Z" -O ${brdc_file_year}.Z
 	if [ ! -e "${brdc_file_year}.Z" ]; then
 		echo "Can't download BRDC file"
 		exit


### PR DESCRIPTION
This PR adds Mac OS X Catalina Compatibility and also changed the anonymous ftp ephemeris file download to authenticated wget download, as per the necessary changes to continue downloading once anonymous ftp is discontinued on Oct. 31st, which is described at: https://cddis.nasa.gov/Data_and_Derived_Products/CDDIS_Archive_Access.html.

It also autodownloads all FGPA images at runtime so that FPGA autoloading can be done on all BladeGPS models.