### PR TITLE
Updated to remove _MACOSX variable and replace it with __APPLE__

### DIFF
--- a/gpssim.c
+++ b/gpssim.c
@@ -14,7 +14,7 @@
 #include <unistd.h>
 // For _kbhit() and _getch() on Linux
 #include <termios.h>
-#ifdef _MACOSX
+#ifdef __APPLE__
 #include <stdio.h>
 #else
 #include <stdio_ext.h> // for __fpurge()
@@ -1950,7 +1950,7 @@ int _getch()
 	int ch;
 	
 	ch = getchar();
-#ifdef _MACOSX
+#ifdef __APPLE__
 	fpurge(stdin); // Clear STDIN buffer
 #else
 	__fpurge(stdin); // Clear STDIN buffer


### PR DESCRIPTION
I couldn't get defining _MACOSX to work, but I think it's unnecessary as we have the automatically populated __APPLE__ variable on osx machines. No need to pass an additional variable.